### PR TITLE
Fix TypeError in admin Applications2 component

### DIFF
--- a/src/components/admin/Applications2.tsx
+++ b/src/components/admin/Applications2.tsx
@@ -41,7 +41,10 @@ const ITEMS_PER_PAGE = 15;
 type ActionType = 'approve' | 'reject';
 
 // Helper function to get admin name from email
-const getAdminName = (email: string): string => {
+const getAdminName = (email: string | undefined | null): string => {
+  if (!email || typeof email !== 'string') {
+    return 'Unknown';
+  }
   const names: Record<string, string> = {
     'dawn@thegarden.pt': 'Dawn',
     'andre@thegarden.pt': 'Andre',


### PR DESCRIPTION
## Summary
- Fixed TypeError "split is not a function" in the admin Applications2 component
- Added proper null/undefined handling in getAdminName function
- Prevents runtime errors when application.final_action.admin is not a valid string

## Problem
The admin panel was throwing a TypeError when trying to display the admin name for final actions. The `getAdminName` function expected a string parameter but could receive undefined or null values from `application.final_action.admin`.

## Solution
Updated the `getAdminName` function to:
1. Accept `string | undefined | null` as parameter type
2. Return 'Unknown' for invalid inputs
3. Only call `.split('@')` after confirming the value is a valid string

## Test plan
- [ ] Navigate to the admin panel applications view
- [ ] Verify no console errors appear when loading applications
- [ ] Check that applications with final_action display correctly
- [ ] Confirm applications without final_action or with invalid admin values display "Unknown" instead of crashing

🤖 Generated with [Claude Code](https://claude.ai/code)