### PR TITLE
Fix additional split errors in Applications2 component

### DIFF
--- a/src/components/admin/Applications2.tsx
+++ b/src/components/admin/Applications2.tsx
@@ -606,8 +606,10 @@ export function Applications2() {
                       if (questions.length > 0 && application.data) {
                         const firstNameQuestion = questions.find(q => q.text === "First Name") as QuestionForAnswerRetrieval | undefined;
                         const lastNameQuestion = questions.find(q => q.text === "Last Name") as QuestionForAnswerRetrieval | undefined;
-                        let firstName = firstNameQuestion ? getAnswer(application.data, firstNameQuestion) || '' : '';
-                        let lastName = lastNameQuestion ? getAnswer(application.data, lastNameQuestion) || '' : '';
+                        const firstNameAnswer = firstNameQuestion ? getAnswer(application.data, firstNameQuestion) : '';
+                        const lastNameAnswer = lastNameQuestion ? getAnswer(application.data, lastNameQuestion) : '';
+                        const firstName = firstNameAnswer ? String(firstNameAnswer) : '';
+                        const lastName = lastNameAnswer ? String(lastNameAnswer) : '';
                         return `${firstName} ${lastName}`.trim() || "Applicant Name Missing";
                       }
                       return "Applicant Name Unavailable";
@@ -767,7 +769,9 @@ export function Applications2() {
                   if (specialWeeksQuestion) {
                     const answer = getAnswer(application.data, specialWeeksQuestion);
                     if (answer && answer !== "No <3") {
-                      const programName = answer.split(" | ")[0] || answer;
+                      const programName = typeof answer === 'string' 
+                        ? (answer.split(" | ")[0] || answer)
+                        : String(answer);
                       return (
                         <span className="inline-flex items-center px-2 py-1 rounded text-xs bg-amber-900/30 text-amber-400 border border-amber-700/50 font-mono">
                           🌟 {programName}


### PR DESCRIPTION
## Summary
- Fixed additional TypeError issues in Applications2 component
- Added proper type checking before string operations
- Ensures robust handling of non-string values from getAnswer function

## Problem
The admin panel was still showing TypeError "split is not a function" even after the first fix. Investigation revealed:
1. The special week answer could be non-string when calling `.split(" | ")`
2. First name and last name values might not be strings when concatenating

## Solution
1. Added type checking before calling `.split()` on special week answer - if not a string, converts to string
2. Ensured firstName and lastName are always converted to strings before concatenation
3. This prevents any potential runtime errors when getAnswer returns unexpected types

## Test plan
- [ ] Clear browser cache (important\!)
- [ ] Navigate to the admin panel applications view
- [ ] Verify no console errors appear when loading applications
- [ ] Check that special week badges display correctly
- [ ] Verify applicant names display properly
- [ ] Test with applications that have missing or non-string data

## Note on deployment
After merging, users may need to clear their browser cache or do a hard refresh (Cmd+Shift+R on Mac, Ctrl+Shift+R on Windows) to load the updated JavaScript bundle.

🤖 Generated with [Claude Code](https://claude.ai/code)